### PR TITLE
Simplifications and Predict for LinearModel

### DIFF
--- a/ar/ar.go
+++ b/ar/ar.go
@@ -2,6 +2,7 @@ package ar
 
 import (
 	"github.com/craigching/timeseries/lm"
+	"gonum.org/v1/gonum/mat"
 )
 
 type AutoRegressiveModel struct {
@@ -27,8 +28,11 @@ func (m *AutoRegressiveModel) Fit(x []float64) {
 	}
 	// Save y so we can predict from it
 	m.y = x[m.order:]
-	c := lm.LinearRegression(X, m.y)
-	m.Coeff = c
+
+	xMat := lm.AsMatrix(X)
+	yMat := lm.AsMatrix(m.y)
+
+	m.Coeff = lm.LinearRegression(xMat, yMat)
 }
 
 func lag(x []float64, shift, n int) []float64 {
@@ -38,21 +42,18 @@ func lag(x []float64, shift, n int) []float64 {
 
 func (m *AutoRegressiveModel) Predict(n int) []float64 {
 
-	// Reverse the coefficients when multiplying to match what R's ar() is doing
-	coeff := make([]float64, len(m.Coeff)-1)
-	copy(coeff, m.Coeff[1:])
-	for i, j := 0, len(coeff)-1; i < j; i, j = i+1, j-1 {
-		coeff[i], coeff[j] = coeff[j], coeff[i]
-	}
-	xint := m.Coeff[0]
+	b := mat.NewDense(len(m.Coeff), 1, m.Coeff)
 
 	for i := 0; i < n; i++ {
 		terms := m.y[len(m.y)-m.order:]
-		sum := xint
-		for i := 0; i < m.order; i++ {
-			sum += terms[i] * coeff[i]
-		}
-		m.y = append(m.y, sum)
+
+		t := []float64{1.0}
+
+		xMat := mat.NewDense(1, len(terms)+1, append(t, terms...))
+		yHat := mat.Dense{}
+		yHat.Mul(xMat, b)
+
+		m.y = append(m.y, yHat.At(0, 0))
 	}
 
 	return m.y[len(m.y)-n:]

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/ajstarks/svgo v0.0.0-20200725142600-7a3c8b57fecb // indirect
 	github.com/go-latex/latex v0.0.0-20201220152147-94de1316b515 // indirect
+	github.com/stretchr/testify v1.2.2
 	golang.org/x/exp v0.0.0-20201221025956-e89b829e73ea // indirect
 	golang.org/x/text v0.3.4 // indirect
 	golang.org/x/tools v0.0.0-20201223010750-3fa0e8f87c1a // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3
 github.com/ajstarks/svgo v0.0.0-20200725142600-7a3c8b57fecb h1:EVl3FJLQCzSbgBezKo/1A4ADnJ4mtJZ0RvnNzDJ44nY=
 github.com/ajstarks/svgo v0.0.0-20200725142600-7a3c8b57fecb/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90 h1:WXb3TSNmHp2vHoCroCIB1foO/yQ36swABL8aOVeDpgg=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
@@ -34,9 +35,11 @@ github.com/phpdave11/gofpdi v1.0.7/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/main.go
+++ b/main.go
@@ -14,11 +14,15 @@ func main() {
 	lm := lm.New()
 	lm.Fit(X, y)
 	fmt.Println("coeffs:", lm.Coeff)
+	wt := []float64{2.620, 3.570}
+	qsec := []float64{16.46, 15.84}
+	pred := lm.Predict([][]float64{wt, qsec})
+	fmt.Println("pred:", pred)
 
 	x := datasets.Lh()
 	ar := ar.New(1)
 	ar.Fit(x)
-	pred := ar.Predict(10)
+	pred = ar.Predict(10)
 	fmt.Println("coeffs:", ar.Coeff)
 	fmt.Println("pred:", pred)
 }


### PR DESCRIPTION
- Simplifies LinearRegression to take gonum Dense matrices. Munging the
data is left to the higher level models.

- Simplifies AutoRegressiveModel.Predict and removes some hacks